### PR TITLE
add project default encoding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,9 @@
 	<module>metamorphosis-commons</module>
 	<module>metamorphosis-server-wrapper</module>
   </modules>
+    <properties>
+        <project.build.sourceEncoding>GBK</project.build.sourceEncoding>
+    </properties>
   <build>
 	<plugins>
 	  <plugin>


### PR DESCRIPTION
为项目增加默认的编码格式, 防止因IDE默认UTF-8的编码格式导致的乱码