### PR TITLE
align mysql-connector-java version to 5.1.6, 5.1.5, 5.1.17 to 5.1.17

### DIFF
--- a/metamorphosis-tools/pom.xml
+++ b/metamorphosis-tools/pom.xml
@@ -72,7 +72,7 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.6</version>
+			<version>5.1.17</version>
 		</dependency>
 		<dependency>
 			<groupId>joda-time</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@
 	  <dependency>
 		<groupId>mysql</groupId>
 		<artifactId>mysql-connector-java</artifactId>
-		<version>5.1.5</version>
+		<version>5.1.17</version>
 	  </dependency>
 	</dependencies>
   </dependencyManagement>


### PR DESCRIPTION
align mysql-connector-java version to avoid inconsistent API behaviors.